### PR TITLE
eager map

### DIFF
--- a/dist-test.js
+++ b/dist-test.js
@@ -483,6 +483,12 @@ TestsMap.set('tryCatch', tryCatch => [
 ])
 
 TestsMap.set('map', map => [
+  Test('eager map', function () {
+    const myArray = [1, 2, 3]
+    const mappedArray = map(myArray, number => number ** 2)
+    assert.deepEqual(mappedArray, [1, 4, 9])
+  }),
+
   Test(
     'map syncMapper',
     map(number => number ** 2))

--- a/dist-test.js
+++ b/dist-test.js
@@ -487,7 +487,7 @@ TestsMap.set('map', map => [
     const myArray = [1, 2, 3]
     const mappedArray = map(myArray, number => number ** 2)
     assert.deepEqual(mappedArray, [1, 4, 9])
-  }),
+  }).case(),
 
   Test(
     'map syncMapper',

--- a/map.js
+++ b/map.js
@@ -64,6 +64,7 @@ const symbolAsyncIterator = require('./_internal/symbolAsyncIterator')
  * ) -> mappingReducer Reducer
  * ```
  */
+
 const _map = function (value, mapper) {
   if (isArray(value)) {
     return arrayMap(value, mapper)
@@ -232,6 +233,16 @@ const _map = function (value, mapper) {
  * console.log(
  *   [1, 2, 3, 4, 5].reduce(squareConcatReducer, ''),
  * ) // '1491625'
+ * ```
+ *
+ * `map`, when passed a single argument before the mapper function, treats that argument as the value to be mapped.
+ *
+ * ```javascript [playground]
+ * const myArray = [1, 2, 3]
+ *
+ * const mappedArray = map(myArray, number => number ** 2)
+ *
+ * console.log(mappedArray) // [1, 4, 9]
  * ```
  *
  * @execution concurrent

--- a/test.js
+++ b/test.js
@@ -807,6 +807,12 @@ describe('rubico', () => {
   })
 
   describe('map', () => {
+    it('eager', async () => {
+      const myArray = [1, 2, 3]
+      const mappedArray = map(myArray, number => number ** 2)
+      assert.deepEqual(mappedArray, [1, 4, 9])
+    })
+
     it('Test', Test('map', map(number => number ** 2))
       .case(Promise.resolve(1), 1)
       .case(Promise.resolve(2), 4)


### PR DESCRIPTION
`map`, when passed a single argument before the mapper function, treats that argument as the value to be mapped.

```js
const myArray = [1, 2, 3]

const mappedArray = map(myArray, number => number ** 2)

console.log(mappedArray) // [1, 4, 9]
```