### PR TITLE
eager filter

### DIFF
--- a/dist-test.js
+++ b/dist-test.js
@@ -656,6 +656,12 @@ TestsMap.set('map.withIndex', mapWithIndex => [
 ])
 
 TestsMap.set('filter', filter => [
+  Test('eager filter', async function () {
+    const numbers = [1, 2, 3]
+    const odds = filter(numbers, number => number % 2 == 1)
+    assert.deepEqual(odds, [1, 3])
+  }).case()
+
   Test(
     'filter syncPredicate',
     filter(number => number % 2 == 1))

--- a/filter.js
+++ b/filter.js
@@ -228,6 +228,16 @@ const _filter = function (value, predicate) {
  * ) // [1, 3, 5]
  * ```
  *
+ * `filter`, when passed a single argument before the predicate function, treats that argument as the value to be filtered.
+ *
+ * ```javascript [playground]
+ * const numbers = [1, 2, 3]
+ *
+ * const odds = filter(numbers, number => number % 2 == 1)
+ *
+ * console.log(odds) // [1, 3]
+ * ```
+ *
  * @execution concurrent
  *
  * @transducing

--- a/test.js
+++ b/test.js
@@ -1303,6 +1303,12 @@ then(() => {
   })
 
   describe('filter', () => {
+    it('eager', async () => {
+      const numbers = [1, 2, 3]
+      const odds = filter(numbers, number => number % 2 == 1)
+      assert.deepEqual(odds, [1, 3])
+    })
+
     describe('filter(predicate T=>Promise|boolean)(Array<T>) -> Promise|Array<T>', () => {
       it('predicate T=>boolean', async () => {
         const isOdd = number => number % 2 == 1


### PR DESCRIPTION
`filter`, when passed a single argument before the predicate function, treats that argument as the value to be filtered.

```js
const numbers = [1, 2, 3]

const odds = filter(numbers, number => number % 2 == 1)

console.log(odds) // [1, 3]
```