### PR TITLE
eager reduce

### DIFF
--- a/dist-test.js
+++ b/dist-test.js
@@ -766,6 +766,12 @@ TestsMap.set('filter.withIndex', filterWithIndex => [
 ])
 
 TestsMap.set('reduce', reduce => [
+  Test('eager reduce', async function () {
+    const numbers = [1, 2, 3, 4, 5]
+    const sum = reduce(numbers, (a, b) => a + b)
+    assert.equal(sum, 15)
+  }).case(),
+
   Test(
     'reduce sync init 0',
     reduce(function add(a, b) { return a + b }, 0))

--- a/reduce.js
+++ b/reduce.js
@@ -160,6 +160,16 @@ const genericReduce = require('./_internal/genericReduce')
  * ) // { A: true, B: true, C: true }
  * ```
  *
+ * `reduce`, when passed a single non-function argument before the reducer function, treats that argument as the value to be reduced.
+ *
+ * ```javascript [playground]
+ * const numbers = [1, 2, 3, 4, 5]
+ *
+ * const sum = reduce(numbers, (a, b) => a + b)
+ *
+ * assert.equal(sum, 15)
+ * ```
+ *
  * @execution series
  *
  * @transducing

--- a/test.js
+++ b/test.js
@@ -1642,6 +1642,12 @@ then(() => {
   })
 
   describe('reduce', () => {
+    it('eager', async () => {
+      const numbers = [1, 2, 3, 4, 5]
+      const sum = reduce(numbers, (a, b) => a + b)
+      assert.equal(sum, 15)
+    })
+
     describe(`
 Reducer<T> (any, T)=>Promise|any
 


### PR DESCRIPTION
`reduce`, when passed a single non-function argument before the reducer function, treats that argument as the value to be reduced.

```js
const numbers = [1, 2, 3, 4, 5]

const sum = reduce(numbers, (a, b) => a + b)

assert.equal(sum, 15)
```