### PR TITLE
fix reduce initializer not being called correctly with eager API

### DIFF
--- a/reduce.js
+++ b/reduce.js
@@ -183,10 +183,15 @@ const reduce = function (...args) {
   if (typeof args[0] != 'function') {
     const reducer = args[1]
     const initialValue = args[2]
+    if (typeof initialValue == 'function') {
+      return genericReduce([args[0]], reducer, initialValue(args[0]))
+    }
     return genericReduce([args[0]], reducer, initialValue)
   }
+
   const reducer = args[0]
   const initialValue = args[1]
+
   if (typeof initialValue == 'function') {
     return function reducing(...args) {
       const result = initialValue(...args)

--- a/test.js
+++ b/test.js
@@ -1656,8 +1656,12 @@ then(() => {
   describe('reduce', () => {
     it('eager', async () => {
       const numbers = [1, 2, 3, 4, 5]
-      const sum = reduce(numbers, (a, b) => a + b)
-      assert.equal(sum, 15)
+      const sum1 = reduce(numbers, (a, b) => a + b)
+      const sum2 = reduce(numbers, (a, b) => a + b, 0)
+      const sum3 = reduce(numbers, (a, b) => a + b, () => 0)
+      assert.equal(sum1, 15)
+      assert.equal(sum2, 15)
+      assert.equal(sum3, 15)
     })
 
     describe(`


### PR DESCRIPTION
This would break previously
```
const sum = reduce(numbers, (a, b) => a + b, () => 0)
console.log(sum) // 15
```