### PR TITLE
Eager API for pick and omit

### DIFF
--- a/omit.js
+++ b/omit.js
@@ -1,15 +1,27 @@
 const deleteByPath = require('./_internal/deleteByPath')
 const copyDeep = require('./_internal/copyDeep')
+const curry2 = require('./_internal/curry2')
+const __ = require('./_internal/placeholder')
+
+// _omit(source Object, paths Array<string>) -> result Object
+const _omit = function (source, paths) {
+  const pathsLength = paths.length,
+    result = copyDeep(source)
+  let pathsIndex = -1
+  while (++pathsIndex < pathsLength) {
+    deleteByPath(result, paths[pathsIndex])
+  }
+  return result
+}
 
 /**
  * @name omit
  *
  * @synopsis
  * ```coffeescript [specscript]
- * var paths Array<string>,
- *   source Object
+ * omit(paths Array<string>)(source Object) -> omitted Object
  *
- * omit(paths)(source) -> omitted Object
+ * omit(source Object, paths Array<string>) -> omitted Object
  * ```
  *
  * @description
@@ -17,7 +29,7 @@ const copyDeep = require('./_internal/copyDeep')
  *
  * ```javascript [playground]
  * console.log(
- *   omit(['_id'])({ _id: '1', name: 'George' }),
+ *   omit({ _id: '1', name: 'George' }, ['_id']),
  * ) // { name: 'George' }
  * ```
  *
@@ -39,15 +51,22 @@ const copyDeep = require('./_internal/copyDeep')
  *   }),
  * ) // { a: { b: { c: 'hello' } } }
  * ```
+ *
+ * Compose `omit` inside a `pipe` with its tacit API
+ *
+ * ```javascript [playground]
+ * pipe({ a: 1, b: 2, c: 3 }, [
+ *   map(number => number ** 2),
+ *   omit(['a', 'b']),
+ *   console.log, // { c: 9 }
+ * ])
+ * ```
  */
-const omit = paths => function omitting(source) {
-  const pathsLength = paths.length,
-    result = copyDeep(source)
-  let pathsIndex = -1
-  while (++pathsIndex < pathsLength) {
-    deleteByPath(result, paths[pathsIndex])
+const omit = function (arg0, arg1) {
+  if (arg1 == null) {
+    return curry2(_omit, __, arg0)
   }
-  return result
+  return _omit(arg0, arg1)
 }
 
 module.exports = omit

--- a/pick.js
+++ b/pick.js
@@ -1,37 +1,10 @@
 const getByPath = require('./_internal/getByPath')
 const setByPath = require('./_internal/setByPath')
+const curry2 = require('./_internal/curry2')
+const __ = require('./_internal/placeholder')
 
-/**
- * @name pick
- *
- * @synopsis
- * ```coffeescript [specscript]
- * pick(keys Array<string>)(object Object) -> result Object
- * ```
- *
- * @description
- * Creates a new object from a source object by selecting provided keys. If a provided key does not exist on the source object, excludes it from the resulting object.
- *
- * ```javascript [playground]
- * console.log(
- *   pick(['hello', 'world'])({ goodbye: 1, world: 2 }),
- * ) // { world: 2 }
- * ```
- *
- * `pick` supports three types of path patterns for nested property access
- *
- *  * dot delimited - `'a.b.c'`
- *  * bracket notation - `'a[0].value'`
- *  * an array of keys or indices - `['a', 0, 'value']`
- *
- * ```javascript [playground]
- * const nested = { a: { b: { c: { d: 1, e: [2, 3] } } } }
- *
- * console.log(pick(['a.b.c.d'])(nested)) // { a: { b: { c: { d: 1 } } } }
- * ```
- */
-
-const pick = keys => function picking(source) {
+// _pick(source Object, keys Array<string>) -> result Object
+const _pick = function (source, keys) {
   if (source == null) {
     return source
   }
@@ -46,6 +19,54 @@ const pick = keys => function picking(source) {
     }
   }
   return result
+}
+
+/**
+ * @name pick
+ *
+ * @synopsis
+ * ```coffeescript [specscript]
+ * pick(object Object, keys Array<string>) -> result Object
+ *
+ * pick(keys Array<string>)(object Object) -> result Object
+ * ```
+ *
+ * @description
+ * Creates a new object from a source object by selecting provided keys. If a provided key does not exist on the source object, excludes it from the resulting object.
+ *
+ * ```javascript [playground]
+ * console.log(
+ *   pick({ goodbye: 1, world: 2 }, ['hello', 'world']),
+ * ) // { world: 2 }
+ * ```
+ *
+ * `pick` supports three types of path patterns for nested property access
+ *
+ *  * dot delimited - `'a.b.c'`
+ *  * bracket notation - `'a[0].value'`
+ *  * an array of keys or indices - `['a', 0, 'value']`
+ *
+ * ```javascript [playground]
+ * const nested = { a: { b: { c: { d: 1, e: [2, 3] } } } }
+ *
+ * console.log(pick(['a.b.c.d'])(nested)) // { a: { b: { c: { d: 1 } } } }
+ * ```
+ *
+ * Compose `pick` inside a `pipe` with its tacit API.
+ *
+ * ```javascript [playground]
+ * pipe({ a: 1, b: 2, c: 3 }, [
+ *   map(number => number ** 2),
+ *   pick(['a', 'c']),
+ *   console.log, // { a: 1, c: 9 }
+ * ])
+ * ```
+ */
+const pick = (arg0, arg1) => {
+  if (arg1 == null) {
+    return curry2(_pick, __, arg0)
+  }
+  return _pick(arg0, arg1)
 }
 
 module.exports = pick

--- a/test.js
+++ b/test.js
@@ -3678,6 +3678,11 @@ flatMap(
       // assert.deepEqual(pick(['a[0][0].d'])({ a: [[{ b: 1, c: 2, d: 3 }]] }), { a: [[{ b: 1, c: 2 }]] })
       // assert.deepEqual(pick(['a[0][0].d'])({ a: [[{ b: 1, c: 2, d: null }]] }), { a: [[{ b: 1, c: 2 }]] })
     })
+    it('eager api', async () => {
+      ade(pick(abc, ['a']), { a: 1 })
+      ade(pick(abc, ['a', 'd']), { a: 1 })
+      ade(pick(abc, ['d']), {})
+    })
   })
 
   describe('omit', () => {

--- a/test.js
+++ b/test.js
@@ -3735,6 +3735,14 @@ flatMap(
     .case(null, null)
     .case({}, {})
     .case([], []))
+
+    it('eager api', async () => {
+      ade(omit(nested, []), nested)
+      ade(omit([1, 2, 3], []), [1, 2, 3])
+      ade(omit(abc, ['a']), { b: 2, c: 3 })
+      ade(omit(abc, ['a', 'd']), { b: 2, c: 3 })
+      ade(omit(abc, ['d']), { a: 1, b: 2, c: 3 })
+    })
   })
 
   describe(`


### PR DESCRIPTION
Enables the option of supplying the data as the first parameter in an eager fashion. That means instead of
```js
pick(['a, b, c'])(myObj)
```

we can now do this
```js
pick(myObj, ['a', 'b', 'c'])
```