### PR TITLE
simplify some of the more complex synopses

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const {
   // compose functions
   pipe, compose,
 
-  // compose effects
+  // handle effects
   tap, forEach,
 
   // control flow

--- a/filter.js
+++ b/filter.js
@@ -93,8 +93,8 @@ const _filter = function (value, predicate) {
  *
  * type Predicate = (
  *   value any,
- *   indexOrKey? number|string,
- *   collection? Filterable,
+ *   indexOrKey number|string,
+ *   collection Filterable,
  * )=>boolean
  *
  * filter(collection Filterable, predicate Predicate) -> result Promise|Filterable

--- a/flatMap.js
+++ b/flatMap.js
@@ -65,6 +65,7 @@ const _flatMap = function (value, flatMapper) {
  * @synopsis
  * ```coffeescript [specscript]
  * type FlatMappable = Array|String|Set|Iterator|AsyncIterator
+ *
  * type Iterable = Iterable|AsyncIterable|Object<value any>
  *
  * type FlatMapper = (

--- a/map.js
+++ b/map.js
@@ -99,30 +99,16 @@ const _map = function (value, mapper) {
  *
  * @synopsis
  * ```coffeescript [specscript]
- * arrayMapperFunc (value any, index number, array Array)=>Promise|any
- * objectMapperFunc (value any, key string, object Object)=>Promise|any
- * setMapperFunc (value any, value, set Set)=>Promise|any
- * mapMapperFunc (value any, key any, originalMap Map)=>Promise|any
- * iteratorMapperFunc (value any)=>any
- * asyncIteratorMapperFunc (value any)=>Promise|any
+ * type Mappable = Array|Object|Set|Map|Iterator|AsyncIterator
  *
- * map(arrayMapperFunc)(value Array) -> result Promise|Array
- * map(value Array, arrayMapperFunc) -> result Promise|Array
+ * type Mapper = (
+ *   value any,
+ *   indexOrKey number|string,
+ *   collection Mappable
+ * )=>(mappedItem Promise|any)
  *
- * map(objectMapperFunc)(value Object) -> result Promise|Array
- * map(value Object, objectMapperFunc) -> result Promise|Array
- *
- * map(setMapperFunc)(value Set) -> result Promise|Set
- * map(value Set, setMapperFunc) -> result Promise|Set
- *
- * map(mapMapperFunc)(value Map) -> result Promise|Map
- * map(value Map, mapMapperFunc) -> result Promise|Map
- *
- * map(iteratorMapperFunc)(value Iterator|Generator) -> result Iterator
- * map(value Iterator|Generator, iteratorMapperFunc) -> result Iterator
- *
- * map(asyncIteratorMapperFunc)(value AsyncIterator) -> result AsyncIterator
- * map(value AsyncIterator, asyncIteratorMapperFunc) -> result AsyncIterator
+ * map(value Mappable, mapper Mapper) -> result Promise|Mappable
+ * map(mapper Mapper)(value Mappable) -> result Promise|Mappable
  * ```
  *
  * @description

--- a/reduce.js
+++ b/reduce.js
@@ -30,15 +30,17 @@ const _reduce = function (collection, reducer, initialValue) {
  *   collection? Foldable,
  * )=>(nextAccumulator Promise|any)
  *
+ * type Resolver = (collection Foldable)=>Promise|any
+ *
  * reduce(
  *   collection Foldable,
  *   reducer Reducer,
- *   initialValue? function|any
+ *   initialValue? Resolver|any
  * ) -> result Promise|any
  *
  * reduce(
  *   reducer Reducer,
- *   initialValue? function|any
+ *   initialValue? Resolver|any
  * )(collection Foldable) -> result Promise|any
  * ```
  *

--- a/transform.js
+++ b/transform.js
@@ -21,21 +21,32 @@ const _transform = function (collection, transducer, initialValue) {
  *
  * @synopsis
  * ```coffeescript [specscript]
- * type Reducer = (result any, item any)=>(result any)
- * type Transducer = Reducer=>Reducer
- * type Transformable = Array|String|Set|TypedArray|{ concat: function }|{ write: function }|Object
  * type Foldable = Iterable|AsyncIterable|Object<value any>
  *
+ * type Reducer = (
+ *   accumulator any,
+ *   value any,
+ *   indexOrKey? number|string,
+ *   collection? Foldable,
+ * )=>(nextAccumulator Promise|any)
+ *
+ * type Transducer = Reducer=>Reducer
+ *
+ * type Transformable =
+ *   Array|String|Set|TypedArray|{ concat: function }|{ write: function }|Object
+ *
+ * type TransformableResolver = (collection Foldable)=>Promise|Transformable
+ *
  * transform(
- *   foldable Foldable,
+ *   collection Foldable,
  *   transducer Transducer,
- *   initialValue? Transformable|(Foldable=>Promise|Transformable),
+ *   initialValue? Transformable|TransformableResolver,
  * ) -> result Promise|Transformable
  *
  * transform(
  *   transducer Transducer,
- *   initialValue? Transformable|(Foldable=>Promise|Transformable),
- * )(foldable Foldable) -> result Promise|Transformable
+ *   initialValue? Transformable|TransformableResolver,
+ * )(collection Foldable) -> result Promise|Transformable
  * ```
  *
  * @description


### PR DESCRIPTION
simplifies and clarifies synopses of `map`, `filter`, `reduce`, `transform`, and `flatMap`