### PR TITLE
refactor Instance to es6 class

### DIFF
--- a/monad/Instance.js
+++ b/monad/Instance.js
@@ -1,14 +1,8 @@
-/* rubico v1.5.0
- * https://github.com/a-synchronous/rubico
- * (c) 2019-2020 Richard Tong
- * rubico may be freely distributed under the MIT license.
- */
-
-'use strict'
-
 const symbolIterator = Symbol.iterator
 
-/*
+const symbolAsyncIterator = Symbol.asyncIterator
+
+/**
  * @name Instance
  *
  * @synopsis
@@ -17,47 +11,192 @@ const symbolIterator = Symbol.iterator
  * @catchphrase
  * Type checking
  */
-const Instance = function(value) {
-  this.value = value
-}
+class Instance {
+  constructor(value) {
+    this.value = value
+  }
 
-/**
- * @name Instance.prototype.map
- *
- * @synopsis
- * <A any, B any>new Instance(value A).map(func A=>B) -> Instance<B>
-Instance.prototype.map = function(func) {
-  return new Instance(func(this.value))
-} */
+  /**
+   * @name Instance.prototype.chain
+   *
+   * @synopsis
+   * <A any, B any>new Instance(x A).chain(f A=>Instance<B>) -> Instance<B>
+   *
+   * @description
+   * For associativity
+   *
+   * @example
+   * const inst = new Instance(3)
+   * console.log(
+   *   inst.chain(number => new Instance(number ** 2))
+   * ) // Instance { 9 }
+   */
+  chain(func) {
+    return func(this.value)
+  }
 
-/**
- * @name Instance.prototype.join
- *
- * @synopsis
- * <T any>new Instance(Instance<T>).join() -> Instance<T>
- *
- * <T any>new Instance(value T).join() -> value T
-Instance.prototype.join = function() {
-  return this.value
-} */
+  /**
+   * @name Instance.prototype.map
+   *
+   * @synopsis
+   * <A any, B any>new Instance(value A).map(func A=>B) -> Instance<B>
+  map(func) {
+    return new Instance(func(this.value))
+  } */
 
-/**
- * @name Instance.prototype.chain
- *
- * @synopsis
- * <A any, B any>new Instance(x A).chain(f A=>Instance<B>) -> Instance<B>
- *
- * @catchphrase
- * For associativity
- *
- * @example
- * const inst = new Instance(3)
- * console.log(
- *   inst.chain(number => new Instance(number ** 2))
- * ) // Instance { 9 }
- */
-Instance.prototype.chain = function(f) {
-  return f(this.value)
+
+  /**
+   * @name Instance.prototype.is
+   *
+   * @synopsis
+   * new Instance(x any).is(ctor function) -> boolean
+   */
+  is(ctor) {
+    const x = this.value
+    return x != null && x.constructor == ctor
+  }
+
+
+  /**
+   * @name Instance.prototype.isString
+   *
+   * @synopsis
+   * new Instance(x any).isString() -> boolean
+   */
+  isString() {
+    const x = this.value
+    return typeof x == 'string' || (x != null && x.constructor == String)
+  }
+
+  /**
+   * @name Instance.prototype.isNumber
+   *
+   * @synopsis
+   * new Instance(x any).isNumber() -> boolean
+   */
+  isNumber() {
+    const x = this.value
+    return typeof x == 'number' || (x != null && x.constructor == Number)
+  }
+
+  /**
+   * @name Instance.prototype.isArray
+   *
+   * @synopsis
+   * new Instance(x any).isArray() -> boolean
+   */
+  isArray() {
+    return Array.isArray(this.value)
+  }
+
+  /**
+   * @name Instance.prototype.isObject
+   *
+   * @synopsis
+   * new Instance(x any).isObject() -> boolean
+   */
+  isObject() {
+    const x = this.value
+    return x != null && x.constructor == Object
+  }
+
+  /**
+   * @name Instance.prototype.isSet
+   *
+   * @synopsis
+   * new Instance(x any).isSet() -> boolean
+   */
+  isSet() {
+    const x = this.value
+    return x != null && x.constructor == Set
+  }
+
+  /**
+   * @name Instance.prototype.isMap
+   *
+   * @synopsis
+   * new Instance(x any).isMap() -> boolean
+   */
+  isMap() {
+    const x = this.value
+    return x != null && x.constructor == Map
+  }
+
+  /**
+   * @name Instance.prototype.isIterable
+   *
+   * @synopsis
+   * new Instance(value any).isIterable() -> boolean
+   */
+  isIterable() {
+    const value = this.value
+    return value != null && typeof value[symbolIterator] == 'function'
+  }
+
+  /**
+   * @name Instance.prototype.isAsyncIterable
+   *
+   * @synopsis
+   * new Instance(value any).isAsyncIterable() -> boolean
+   */
+  isAsyncIterable() {
+    const value = this.value
+    return value != null && typeof value[symbolAsyncIterator] == 'function'
+  }
+
+  /**
+   * @name Instance.prototype.isFunction
+   *
+   * @synopsis
+   * new Instance(x any).isFunction() -> boolean
+   */
+  isFunction() {
+    return typeof this.value == 'function'
+  }
+
+  /**
+   * @name Instance.prototype.isReadable
+   *
+   * @synopsis
+   * new Instance(x any).isReadable() -> boolean
+   */
+  isReadable() {
+    const x = this.value
+    return x != null && typeof x.read == 'function'
+  }
+
+  /**
+   * @name Instance.prototype.isWritable
+   *
+   * @synopsis
+   * new Instance(x any).isWritable() -> boolean
+   */
+  isWritable() {
+    const x = this.value
+    return x != null && typeof x.write == 'function'
+  }
+
+  /**
+   * @name Instance.prototype.isPromise
+   *
+   * @synopsis
+   * new Instance(x any).isPromise() -> boolean
+   */
+  isPromise() {
+    const x = this.value
+    return x != null && typeof x.then == 'function'
+  }
+
+  /**
+   * @name Instance.prototype.isTypedArray
+   *
+   * @synopsis
+   * new Instance(x any).isTypedArray() -> boolean
+   */
+  isTypedArray() {
+    return ArrayBuffer.isView(this.value)
+  }
+
 }
 
 /*
@@ -82,17 +221,6 @@ Instance.isInstance = x => x != null
 Instance.is = (x, constructor) => x != null && x.constructor == constructor
 
 /*
- * @name Instance.prototype.is
- *
- * @synopsis
- * new Instance(x any).is(constructor function) -> boolean
- */
-Instance.prototype.is = function(constructor) {
-  const x = this.value
-  return x != null && x.constructor == constructor
-}
-
-/*
  * @name Instance.isString
  *
  * @synopsis
@@ -100,17 +228,6 @@ Instance.prototype.is = function(constructor) {
  */
 Instance.isString = x => (
   typeof x == 'string' || (x != null && x.constructor == String))
-
-/*
- * @name Instance.prototype.isString
- *
- * @synopsis
- * new Instance(x any).isString() -> boolean
- */
-Instance.prototype.isString = function() {
-  const x = this.value
-  return typeof x == 'string' || (x != null && x.constructor == String)
-}
 
 /*
  * @name Instance.isNumber
@@ -122,33 +239,12 @@ Instance.isNumber = x => (
   typeof x == 'number' || (x != null && x.constructor == Number))
 
 /*
- * @name Instance.prototype.isNumber
- *
- * @synopsis
- * new Instance(x any).isNumber() -> boolean
- */
-Instance.prototype.isNumber = function() {
-  const x = this.value
-  return typeof x == 'number' || (x != null && x.constructor == Number)
-}
-
-/*
  * @name Instance.isArray
  *
  * @synopsis
  * Instance.isArray(x any) -> boolean
  */
 Instance.isArray = Array.isArray
-
-/*
- * @name Instance.prototype.isArray
- *
- * @synopsis
- * new Instance(x any).isArray() -> boolean
- */
-Instance.prototype.isArray = function() {
-  return Array.isArray(this.value)
-}
 
 /*
  * @name Instance.isObject
@@ -159,17 +255,6 @@ Instance.prototype.isArray = function() {
 Instance.isObject = x => x != null && x.constructor == Object
 
 /*
- * @name Instance.prototype.isObject
- *
- * @synopsis
- * new Instance(x any).isObject() -> boolean
- */
-Instance.prototype.isObject = function() {
-  const x = this.value
-  return x != null && x.constructor == Object
-}
-
-/*
  * @name Instance.isSet
  *
  * @synopsis
@@ -178,34 +263,12 @@ Instance.prototype.isObject = function() {
 Instance.isSet = x => x != null && x.constructor == Set
 
 /*
- * @name Instance.prototype.isSet
- *
- * @synopsis
- * new Instance(x any).isSet() -> boolean
- */
-Instance.prototype.isSet = function() {
-  const x = this.value
-  return x != null && x.constructor == Set
-}
-
-/*
  * @name Instance.isMap
  *
  * @synopsis
  * Instance.isMap(x any) -> boolean
  */
 Instance.isMap = x => x != null && x.constructor == Map
-
-/*
- * @name Instance.prototype.isMap
- *
- * @synopsis
- * new Instance(x any).isMap() -> boolean
- */
-Instance.prototype.isMap = function() {
-  const x = this.value
-  return x != null && x.constructor == Map
-}
 
 /*
  * @name Instance.isIterable
@@ -218,36 +281,12 @@ Instance.isIterable = function isIterable(value) {
 }
 
 /*
- * @name Instance.prototype.isIterable
- *
- * @synopsis
- * new Instance(value any).isIterable() -> boolean
- */
-Instance.prototype.isIterable = function isIterable() {
-  const value = this.value
-  return value != null && typeof value[symbolIterator] == 'function'
-}
-
-const symbolAsyncIterator = Symbol.asyncIterator
-
-/*
  * @name Instance.isAsyncIterable
  *
  * @synopsis
  * Instance.isAsyncIterable(value any) -> boolean
  */
 Instance.isAsyncIterable = function isAsyncIterable(value) {
-  return value != null && typeof value[symbolAsyncIterator] == 'function'
-}
-
-/*
- * @name Instance.prototype.isAsyncIterable
- *
- * @synopsis
- * new Instance(value any).isAsyncIterable() -> boolean
- */
-Instance.prototype.isAsyncIterable = function() {
-  const value = this.value
   return value != null && typeof value[symbolAsyncIterator] == 'function'
 }
 
@@ -260,33 +299,12 @@ Instance.prototype.isAsyncIterable = function() {
 Instance.isFunction = x => typeof x == 'function'
 
 /*
- * @name Instance.prototype.isFunction
- *
- * @synopsis
- * new Instance(x any).isFunction() -> boolean
- */
-Instance.prototype.isFunction = function() {
-  return typeof this.value == 'function'
-}
-
-/*
  * @name Instance.isReadable
  *
  * @synopsis
  * Instance.isReadable(x any) -> boolean
  */
 Instance.isReadable = x => x != null && typeof x.read == 'function'
-
-/*
- * @name Instance.prototype.isReadable
- *
- * @synopsis
- * new Instance(x any).isReadable() -> boolean
- */
-Instance.prototype.isReadable = function() {
-  const x = this.value
-  return x != null && typeof x.read == 'function'
-}
 
 /*
  * @name Instance.isWritable
@@ -297,17 +315,6 @@ Instance.prototype.isReadable = function() {
 Instance.isWritable = x => x != null && typeof x.write == 'function'
 
 /*
- * @name Instance.prototype.isWritable
- *
- * @synopsis
- * new Instance(x any).isWritable() -> boolean
- */
-Instance.prototype.isWritable = function() {
-  const x = this.value
-  return x != null && typeof x.write == 'function'
-}
-
-/*
  * @name Instance.isPromise
  *
  * @synopsis
@@ -316,36 +323,11 @@ Instance.prototype.isWritable = function() {
 Instance.isPromise = x => x != null && typeof x.then == 'function'
 
 /*
- * @name Instance.prototype.isPromise
- *
- * @synopsis
- * new Instance(x any).isPromise() -> boolean
- */
-Instance.prototype.isPromise = function() {
-  const x = this.value
-  return x != null && typeof x.then == 'function'
-}
-
-/*
  * @name Instance.isTypedArray
  *
  * @synopsis
  * Instance.isTypedArray(x any) -> boolean
  */
 Instance.isTypedArray = ArrayBuffer.isView
-
-// Instance.isTypedArrayCandidate0 = x => x != null && typedArrayConstructorNames.has(x.constructor.name)
-
-// Instance.isTypedArrayCandidate1 = ArrayBuffer.isView
-
-/*
- * @name Instance.prototype.isTypedArray
- *
- * @synopsis
- * new Instance(x any).isTypedArray() -> boolean
- */
-Instance.prototype.isTypedArray = function() {
-  return ArrayBuffer.isView(this.value)
-}
 
 module.exports = Instance


### PR DESCRIPTION
uses the `class` syntax over function prototype, resolves TS compilation error in https://github.com/a-synchronous/rubico/pull/269