### PR TITLE
nit: refer to 'Monad' as "Relative monad"

### DIFF
--- a/flatMap.js
+++ b/flatMap.js
@@ -79,13 +79,13 @@ const _flatMap = function (value, flatMapper) {
  * ```
  *
  * @description
- * Applies a flatMapper function to each element of a monad, returning a monad of the same type.
+ * Applies a flatMapper function to each element of a relative monad, returning a relative monad of the same type.
  *
- * A flatMapping operation iterates through each element of a monad and applies the flatMapper function to each element, flattening the result of the execution into the returned monad.
+ * A flatMapping operation iterates through each element of a relative monad and applies the flatMapper function to each element, flattening the result of the execution into the returned relative monad.
  *
- * If the flatMapper is asynchronous, it is executed concurrently. The execution result may be asynchronously iterable, in which case it is muxed into the returned monad.
+ * If the flatMapper is asynchronous, it is executed concurrently. The execution result may be asynchronously iterable, in which case it is muxed into the returned relative monad.
  *
- * The following data types are considered to be monads, all are flattenable into other monads:
+ * The following data types are considered to be relative monads, all are flattenable into other relative monads:
  *  * `array`
  *  * `string`
  *  * `set`


### PR DESCRIPTION
I was linked to this project and its depiction of monads as I study monads.

It lists several JS types, such as `array` and `string` as monads. However, monads are a functor in some category. If we imagine JS to be a category with JS (duck) "types" as objects and morphisms as functions, then a monad would take one type to another type. Thus, array can be a monad, but string isn't necessarily one, as it is only ever string.

However, there is a generalization of monads called relative monads which may fit the description here of "having a flatMap operation". A relative monad on $$C$$ is relative to some functor $$J:A\to C$$. If we let $$A$$ be the terminal category $$\top$$ and $$J$$ be the constant functor $$Δ_\mathtt{UTF16}:\top\to\mathsf{JS}$$, then $$\mathtt{array}\circ J$$ is the same as $$\mathtt{string}$$. Thus, $$\mathtt{string}$$ becomes a relative monad as a [special case](https://ncatlab.org/nlab/show/relative+monad#generic_examples) of the monad $$\mathtt{array}$$.